### PR TITLE
fix #305: error index out of bounds (get_lines)

### DIFF
--- a/lua/formatter/util.lua
+++ b/lua/formatter/util.lua
@@ -137,7 +137,7 @@ function M.set_lines(bufnr, startLine, endLine, lines)
 end
 
 function M.get_lines(bufnr, startLine, endLine)
-    return vim.api.nvim_buf_get_lines(bufnr, startLine, endLine, true)
+    return vim.api.nvim_buf_get_lines(bufnr, startLine, endLine, false)
 end
 
 function M.fire_event(event, silent)
@@ -210,3 +210,11 @@ else
 end
 
 return M
+
+
+
+
+
+
+
+


### PR DESCRIPTION
resolves #305 and #328

The errors documented in the above issues came from the line ranges of the document conflicting with what `formatter.nvim` saw. It would often happen on newly created empty buffers, which had lines added to them, which were then attempted to be formatted (i.e. before saving, closing and reopening the buffer, in which case the error would not occur).

The error was being returned by the `nvim_buf_get_lines` api call, which was set to strict indexing.

This PR changes ignores strict indexing, which is in keeping with the current approach already implemented in the `nvim_buf_set_lines`.

I therefore thought it was an idiomatic approach given this code base.

In general I also think it's acceptable to ignore this error as the formatting calls always operate on the whole buffer anyway, meaning the range is always maximum.
